### PR TITLE
Solving #177 and #193 (#205)

### DIFF
--- a/core/Admin/ActionsMenu.php
+++ b/core/Admin/ActionsMenu.php
@@ -149,6 +149,8 @@ class ActionsMenu implements SidebarMenuEntryListener, CallbackListener, Maniali
 	 * @internal
 	 */
 	public function rebuildAndShowAdminMenu() {
+		$this->maniaControl->getManialinkManager()->hideManialink(self::MLID_ADMIN_MENU);
+
 		$admins = $this->maniaControl->getAuthenticationManager()->getConnectedAdmins(AuthenticationManager::AUTH_LEVEL_MODERATOR);
 		if (!empty($admins)) {
 			$manialink = $this->buildAdminMenuManiaLink();
@@ -161,6 +163,8 @@ class ActionsMenu implements SidebarMenuEntryListener, CallbackListener, Maniali
 	 * @internal
 	 */
 	public function rebuildAndShowPlayerMenu() {
+		$this->maniaControl->getManialinkManager()->hideManialink(self::MLID_PLAYER_MENU);
+
 		$players = $this->maniaControl->getPlayerManager()->getPlayers();
 		if (!empty($players)) {
 			$manialink = $this->buildPlayerMenuManiaLink();

--- a/core/Admin/AuthenticationManager.php
+++ b/core/Admin/AuthenticationManager.php
@@ -391,6 +391,8 @@ class AuthenticationManager implements CallbackListener, EchoListener, Communica
 		$player->authLevel = $authLevel;
 		$this->maniaControl->getCallbackManager()->triggerCallback(self::CB_AUTH_LEVEL_CHANGED, $player);
 
+		$this->maniaControl->getActionsMenu()->rebuildAndShowAdminMenu();
+
 		return true;
 	}
 

--- a/core/Configurator/Configurator.php
+++ b/core/Configurator/Configurator.php
@@ -197,7 +197,7 @@ class Configurator implements CallbackListener, CommandListener, ManialinkPageAn
 		$quadSubstyle = $this->maniaControl->getSettingManager()->getSettingValue($this, self::SETTING_MENU_SUBSTYLE);
 
 		$menuListWidth  = $menuWidth * 0.3;
-		$menuItemHeight = 10.;
+		$menuItemHeight = 9.;
 		$subMenuWidth   = $menuWidth - $menuListWidth;
 		$subMenuHeight  = $menuHeight;
 


### PR DESCRIPTION
* ServerUIPropertiesMenu for Configurator to edit builtin UIProperties of MP

* fixed unregister-functions of CallbackManager

* Reducing menuItemHeight in Configurator to avoid overlapping of the menu items

* Fully rebuild the admins menu after a player rights changed